### PR TITLE
Append VulkanSDK to /LIBPATH

### DIFF
--- a/myapp/buildfile
+++ b/myapp/buildfile
@@ -5,3 +5,8 @@ import libs += libimgui-render-vulkan%lib{imgui-render-vulkan}
 exe{myapp}: {hxx ixx txx cxx}{**} $libs testscript
 
 cxx.poptions =+ "-I$out_root" "-I$src_root"
+
+if ($cxx.target.class == 'windows')
+{
+  cxx.loptions =+ "/LIBPATH:C:/VulkanSDK/1.3.236.0/Lib"
+}

--- a/myapp/buildfile
+++ b/myapp/buildfile
@@ -8,5 +8,5 @@ cxx.poptions =+ "-I$out_root" "-I$src_root"
 
 if ($cxx.target.class == 'windows')
 {
-  cxx.loptions =+ "/LIBPATH:C:/VulkanSDK/1.3.236.0/Lib"
+  cxx.loptions =+ "/LIBPATH:C:/VulkanSDK/*/Lib"
 }


### PR DESCRIPTION
This is necessary to allow build2 to determine Vulkan's libraries and includes under Windows.